### PR TITLE
予約・予約削除の日時ポリシー変更

### DIFF
--- a/src/usecase/reservation_or_disabled/deleteReservation.ts
+++ b/src/usecase/reservation_or_disabled/deleteReservation.ts
@@ -26,9 +26,9 @@ export async function deleteReservation(
 	}
 
 	const now_date = new Date();
-	// 24時間以内であればキャンセル不可
-	if (reservation_for_delete.value.date.getTime() - now_date.getTime() < 24 * 60 * 60 * 1000) {
-		return err(new Error('当日の予約はキャンセルできません。'));
+	// 過去の予約はキャンセルできない
+	if (reservation_for_delete.value.date.getTime() - now_date.getTime() < 0) {
+		return err(new Error('過去の予約はキャンセルできません。'));
 	}
 
 	const delete_reservation_result = await deleteReservationByRordId(dependencies, rord_uuid);

--- a/src/usecase/reservation_or_disabled/deleteReservation.ts
+++ b/src/usecase/reservation_or_disabled/deleteReservation.ts
@@ -21,8 +21,6 @@ export async function deleteReservation(
 	if (reservation_for_delete.value.status !== 'reserved' || reservation_for_delete.value.user_id === null) {
 		return err(new Error('予約ではなく、利用禁止の日時です。'));
 	}
-	console.log(reservation_for_delete.value.user_id);
-	console.log(user_id);
 	if (reservation_for_delete.value.user_id.user_id !== user_id.user_id) {
 		return err(new Error('他のユーザの予約はキャンセルできません。'));
 	}

--- a/src/usecase/reservation_or_disabled/postReservation.ts
+++ b/src/usecase/reservation_or_disabled/postReservation.ts
@@ -17,9 +17,10 @@ export async function postReservation(
 	slot: SlotValue,
 	user_id: UserIdValue
 ): Promise<Result<void, Error>> {
-	// まず、本日より前の日付であればエラー
-	if (date < new Date()) {
-		return err(new Error('過去・当日の日付は予約できません。'));
+	const now_date = new Date();
+	// 過去の日付は予約できない
+	if (date.getTime() - now_date.getTime() < 0) {
+		return err(new Error('過去の日付は予約できません。'));
 	}
 
 	// 念の為、平日であることを確認


### PR DESCRIPTION
## 背景

- 予約削除は3日前まで可能となっていたが、当日以降であれば可能にしてほしい要望
- 予約作成についても当日以降であれば可能にしてほしい要望

## 機能変更

- 予約削除の制限変更
- 予約作成の制限変更

できるだけコードの記法は揃えるようにした